### PR TITLE
Fix bigfoot styles loading

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,8 +35,11 @@
   {% feed_meta %}
   <!-- CSS -->
   <link rel="stylesheet" href="{{ site.baseurl }}/styles.css">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Serif+KR" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Libre+Baskerville:400,400i,700">
   <link rel="stylesheet" href="https://fonts.googleapis.com/earlyaccess/notosanskr.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/bigfoot-default.css">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/bigfoot-number.css">
 
   <!-- You can use Open Graph tags to customize link previews.
      Learn more: https://developers.facebook.com/docs/sharing/webmasters -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,9 +2,6 @@
 <html lang="en">
 
   {% include head.html %}
-  <link href="https://fonts.googleapis.com/css?family=Noto+Serif+KR" rel="stylesheet">
-  <link rel="stylesheet" href="{{ site.baseurl }}/css/bigfoot-default.css">
-  <link rel="stylesheet" href="{{ site.baseurl }}/css/bigfoot-number.css">
   <body>
     <nav class="nav">
       <div class="nav-container">


### PR DESCRIPTION
## Summary
- remove bigfoot stylesheet links from default layout
- move them to the head include so they are inside `<head>`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_683fbf75ed108330b4b9c8a834aa52c6